### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-purple-forest-061720b03.yml
+++ b/.github/workflows/azure-static-web-apps-purple-forest-061720b03.yml
@@ -13,6 +13,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')


### PR DESCRIPTION
Potential fix for [https://github.com/goncalvesj/m3u-split/security/code-scanning/13](https://github.com/goncalvesj/m3u-split/security/code-scanning/13)

In general, this problem is fixed by explicitly configuring the permissions of `GITHUB_TOKEN` in the workflow (either at the top level or per job) so that only the minimal access needed is granted. For this Azure Static Web Apps workflow, the GitHub token is primarily used by `Azure/static-web-apps-deploy@v1` for GitHub integrations (PR comments, statuses). That action typically needs read access to repository contents and limited write access to pull request metadata. It does not need write access to repository contents or other broad scopes.

The best fix without changing existing behavior is to add a top-level `permissions` block so it applies to both `build_and_deploy_job` and `close_pull_request_job`. We can set `contents: read` (to allow the workflow and actions to read the repo) and `pull-requests: write` (to allow the Azure action to post PR comments and statuses). No other scopes are obviously required by the current steps. Concretely, in `.github/workflows/azure-static-web-apps-purple-forest-061720b03.yml`, insert a `permissions:` section after the `on:` block (after line 15) and before `jobs:`. No imports or additional methods are needed since this is GitHub Actions YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
